### PR TITLE
Fix VBox memory management functions for FreeBSD

### DIFF
--- a/mount_vboxfs/Makefile
+++ b/mount_vboxfs/Makefile
@@ -7,7 +7,7 @@ MAN=		mount_vboxfs.8
 
 FREEBSD_SRC?=	${.CURDIR}/../../freebsd
 .if !exists(${FREEBSD_SRC})
-FREEBSD_SRC?=	/usr/src
+FREEBSD_SRC=	/usr/src
 .endif
 MOUNT=		${FREEBSD_SRC}/sbin/mount
 


### PR DESCRIPTION
Current memobj implementation assumes that kernel memory requires to be locked down before used. This is not true for FreeBSD, it's always wired. So rtR0MemObjNativeLockInMap should be no-op for kernel memory. Also fix rtR0MemObjNativeFree and rtR0MemObjNativeGetPagePhysAddr accordingly