### PR TITLE
Corrected destination path for patch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build:
 cp -R $(freebsd-vboxsf)/mount_vboxfs /usr/src/sbin
 cd /usr/src/sbin/mount_vboxfs && make depend all install
 
-cp $(freebsd-vboxsf)/patch-* /usr/ports/emulators/virtualbox-ose/files
+cp $(freebsd-vboxsf)/patch-* /usr/ports/emulators/virtualbox-ose-additions/files
 
 cd /usr/ports/emulators/virtualbox-ose-additions
 make patch


### PR DESCRIPTION
The patch files should be copied to virtualbox-ose-additions instead of virtualbox-ose. Looks like a typo.